### PR TITLE
Add dynamic parameter handling

### DIFF
--- a/GithubProvider/GithubProvider.cs
+++ b/GithubProvider/GithubProvider.cs
@@ -9,6 +9,7 @@ using System.Collections.ObjectModel;
 using Octokit.Internal;
 using Octokit.Caching;
 using System.Collections.Generic;
+using Microsoft.PowerShell.Commands;
 
 namespace GithubProvider
 {
@@ -39,7 +40,7 @@ namespace GithubProvider
 
         public object GetContentReaderDynamicParameters(string path)
         {
-            return null;
+            return new FileSystemContentReaderDynamicParameters();
         }
 
         public IContentWriter GetContentWriter(string path)
@@ -78,7 +79,7 @@ namespace GithubProvider
 
         public object GetContentWriterDynamicParameters(string path)
         {
-            return null;
+            return new FileSystemContentWriterDynamicParameters();
         }
 
         protected override bool IsValidPath(string path)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,3 @@
-os: Unstable
-
 environment:
   GITHUB_TOKEN:
     secure: XHO7MYVx17hrAWLVGs1eGJZcIRczb4ddHrFZj/Be3mVO54ITNLpXR5uquH/9MqAl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+os: Unstable
+
 environment:
   GITHUB_TOKEN:
     secure: XHO7MYVx17hrAWLVGs1eGJZcIRczb4ddHrFZj/Be3mVO54ITNLpXR5uquH/9MqAl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,4 @@ test_script:
   - ps: .\test.ps1
     
 deploy_script:
-  - ps: cp GithubFS c:/Modules/GithubFS
-  - ps: publish-module -Name GithubFS -NugetApiToken $env:PSGALLERY_TOKEN
-    on:
-      branch: master
-      appveyor_repo_tag: true 
+  - ps: "if ($env:APPVEYOR_REPO_TAG) { cp GithubFS c:/Modules/GithubFS; publish-module -Name GithubFS -NugetApiToken $env:PSGALLERY_TOKEN }"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ install:
   - ps: mkdir c:/Modules
   - ps: $env:PSModulePath += ";c:\Modules\"
   - ps: cinst pester -y
+  - ps: Get-PackageProvider -Name NuGet -Force
     
 before_build:
   - ps: pushd GithubProvider

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ test_script:
   - ps: .\test.ps1
     
 deploy_script:
-  - ps: "if ($env:APPVEYOR_REPO_TAG) { cp GithubFS c:/Modules/GithubFS; publish-module -Name GithubFS -NugetApiToken $env:PSGALLERY_TOKEN }"
+  - ps: "if ($env:APPVEYOR_REPO_TAG -eq 'true') { cp GithubFS c:/Modules/GithubFS; publish-module -Name GithubFS -NugetApiToken $env:PSGALLERY_TOKEN }"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Unstable
+os: WMF 5
 
 environment:
   GITHUB_TOKEN:


### PR DESCRIPTION
This way `get-content` and `set-content` accept the same args for the github provider as the fs provider advertises - this is what makes one of the pester tests fail right now (it calls `get-content` with `-Encoding UTF8`.
